### PR TITLE
Fix Sync Wiki jobs stuck on actions-runners

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -17,14 +17,26 @@ permissions:
 
 jobs:
   wiki-sync:
-    uses: ./.github/workflows/wiki-sync.yml
-    with:
-      github_app_id: ${{ vars.RESIZES_AGENTIC_AI_APP_ID }}
-      docs_repository_owner: resizes
-      docs_repository: internal-technical-docs
-      litellm_base_url: ${{ vars.LITELLM_BASE_URL }}
-      dry_run: ${{ inputs.dry_run || false }}
-      runner: actions-runners
-    secrets:
-      github_app_private_key: ${{ secrets.RESIZES_AGENTIC_AI_PRIVATE_KEY }}
-      litellm_api_key: ${{ secrets.LITELLM_API_KEY }}
+    name: Sync Wiki
+    runs-on: actions-runners
+
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run wiki sync
+        uses: ./wiki-sync
+        with:
+          github_app_id: ${{ vars.RESIZES_AGENTIC_AI_APP_ID }}
+          github_app_private_key: ${{ secrets.RESIZES_AGENTIC_AI_PRIVATE_KEY }}
+          docs_repository_owner: resizes
+          docs_repository: internal-technical-docs
+          docs_branch: main
+          before_sha: ${{ github.event.before || '0000000000000000000000000000000000000000' }}
+          after_sha: ${{ github.sha }}
+          config_path: .github/wiki-sync.yml
+          litellm_base_url: ${{ vars.LITELLM_BASE_URL }}
+          litellm_api_key: ${{ secrets.LITELLM_API_KEY }}
+          dry_run: ${{ inputs.dry_run || false }}


### PR DESCRIPTION
## Summary
- Inline the wiki-sync job in `sync-wiki.yml` instead of calling the reusable workflow
- Reusable `workflow_call` jobs are not dispatched to ARC runner scale sets, which left Sync Wiki runs queued indefinitely on `actions-runners`

## Test plan
- [x] Verified direct `runs-on: actions-runners` jobs are assigned by the scale set listener in resizes/production EKS
- [ ] Merge and confirm Sync Wiki workflow_dispatch completes

Made with [Cursor](https://cursor.com)