### PR TITLE
Update default model to 'ollama_chat/qwen3.5:27b'

### DIFF
--- a/wiki-sync/scripts/wiki_sync.py
+++ b/wiki-sync/scripts/wiki_sync.py
@@ -282,7 +282,7 @@ def build_prompt(
     ).strip()
 
 
-DEFAULT_LITELLM_MODEL = "ollama_chat/glm-5:cloud"
+DEFAULT_LITELLM_MODEL = "ollama_chat/qwen3.5:27b"
 
 
 def resolve_litellm_model(*, base_url: str, api_key: str, configured_model: str = "") -> str:


### PR DESCRIPTION
## What

Updates the default LiteLLM model in the wiki sync action from the retired `ollama_chat/glm-5:cloud` to `ollama_chat/qwen3.5:27b`.

## Why

`glm-5:cloud` was retired on 2026-07-15, causing wiki sync failures across all repositories:
Ollama_chatException: "glm-5 was retired at 2026-07-15 00:00:00 -0700 PDT"

`qwen3.5:27b` is already available in the internal Ollama cluster and is a strong general-purpose model for structured instruction following.

## Changes

- `wiki-sync/scripts/wiki_sync.py`: `DEFAULT_LITELLM_MODEL = "ollama_chat/glm-5:cloud"` → `"ollama_chat/qwen3.5:27b"`

## After merge

All repositories using the `resizes/github-actions/.github/workflows/wiki-sync.yml` workflow will start working again on their next push.
