### PR TITLE
revert(model): default model to glm-5

### DIFF
--- a/wiki-sync/scripts/wiki_sync.py
+++ b/wiki-sync/scripts/wiki_sync.py
@@ -282,7 +282,7 @@ def build_prompt(
     ).strip()
 
 
-DEFAULT_LITELLM_MODEL = "ollama_chat/qwen3.5:27b"
+DEFAULT_LITELLM_MODEL = "ollama_chat/glm-5:cloud"
 
 
 def resolve_litellm_model(*, base_url: str, api_key: str, configured_model: str = "") -> str:


### PR DESCRIPTION
## What

Keeps the wiki sync default model name as `ollama_chat/glm-5:cloud`.

## Why

In LiteLLM, the model **name** `glm-5:cloud` has been repointed to `glm-5.2` behind the scenes, so the LiteLLM-facing identifier stays the same even though the underlying Ollama model changed. Reverting the name in this repo lets the shared action continue using the existing LiteLLM configuration.

## Changes

- `wiki-sync/scripts/wiki_sync.py`: restore `DEFAULT_LITELLM_MODEL = "ollama_chat/glm-5:cloud"`

## Related

- Supersedes the model-name change in the existing `fix(model)--change-deprecated-glm-5-default-model` branch
- Fixes wiki sync failures caused by pointing to a different LiteLLM model identifier