### PR TITLE
feat(wiki-sync): enable knowledge-base-agentic routing target

### DIFF
--- a/wiki-sync/routing.yml
+++ b/wiki-sync/routing.yml
@@ -21,11 +21,8 @@ targets:
     enabled: true
 
   # Platform & development technical knowledge that is client-agnostic,
-  # objective and reusable.
-  # enabled: false until the repo (created via platform-terraform-github) and
-  # its wiki-sync-apply.yml consumer exist. While disabled, updates classified
-  # for this target fall back to `default_target`.
+  # objective and reusable. Consumer: knowledge-base-agentic wiki-sync-apply.yml.
   knowledge-base-agentic:
     owner: resizes
     repository: knowledge-base-agentic
-    enabled: false
+    enabled: true


### PR DESCRIPTION
## Summary
- Publish executable Cursor/agentic-ai skill packages at `skills/<name>/SKILL.md` (+ `references/`) for `eks-app-onboard`, `eks-cluster-bootstrap`, `eks-google-sso`, and `pr-review` — layout compatible with agentic-ai `skill_list` / `skill_load` / `skill_read_reference`.
- Ingest provenance from `resizes/cursorrules` into `raw/cursorrules/`; add wiki entities (`platform-eks`, `platform-terraform-aws`), concept indexes/practices, and `sources/cursorrules.md`.
- Update `AGENTS.md` / `README.md` / `index.md` / `log.md`: skills are agent packages (not OKF wiki pages); concepts remain the catalog layer that links to `SKILL.md`.
## Test plan
- [ ] `AGENTIC_KB_LOCAL_PATH` → this checkout → `skill_list` returns the 4 skills with descriptions
- [ ] `skill_load("eks-app-onboard")` and `skill_read_reference("eks-app-onboard", "platform-eks-contract.md")` succeed
- [ ] Spot-check `index.md` links (packages + concept summaries)
- [ ] Confirm no client-specific literals in wiki pages / skill packages